### PR TITLE
Simplified expressions in closures to fix compiler errors

### DIFF
--- a/Fabled/Sources/NextRankupCard.swift
+++ b/Fabled/Sources/NextRankupCard.swift
@@ -28,7 +28,7 @@ final class NextRankupCard: CardView {
 
   init(gloryRemaining: Binding<Int>, winsRemaining: Binding<UInt>) {
     gloryToNextRankValue = gloryRemaining.map(String.init)
-    winsToGoText = winsRemaining.map { String($0) + ($0 == 1 ? " win" : " wins") + " to go"}
+    winsToGoText = winsRemaining.map { $0 + $0 == 1 ? " win" : " wins" + " to go" }
     super.init()
   }
 

--- a/Fabled/Sources/RecentActivityCard.swift
+++ b/Fabled/Sources/RecentActivityCard.swift
@@ -34,8 +34,8 @@ final class RecentActivityCard: CardView {
 
   init(winStreak: Binding<UInt>, matchesPlayed: Binding<Int>, matchesWon: Binding<Int>) {
     currentWinStreakValue = winStreak.map(String.init)
-    matchesThisWeekText = matchesPlayed.map { String($0) + ($0 == 1 ? " match" : " matches") + " this week" }
-    winsThisWeekText = matchesWon.map { String($0) + ($0 == 1 ? " win" : " wins") + " this week" }
+		matchesThisWeekText = matchesPlayed.map { $0 + $0 == 1 ? " match" : " matches" + " this week" }
+    winsThisWeekText = matchesWon.map { $0 + $0 == 1 ? " win" : " wins" + " this week" }
     super.init()
   }
 


### PR DESCRIPTION
Hello, newbie newsletter subscriber here. This took me significantly more than 15 minutes and I am not at all sure of the changes, since I am not comfortable with using .map, but I did manage to get rid of the compiler errors and get the app to build. I am not sure if the new expressions though (such as `matchesThisWeekText = matchesPlayed.map { $0 + $0 == 1 ? " match" : " matches" + " this week" }`) will return the expected strings, since I would think that the Binding<Int> that's in $0 somehow needs to be coerced. Would welcome any feedback and will do my best to understand it. Fun way to learn!